### PR TITLE
fix:corrige contagem de visualizações dos cálculos

### DIFF
--- a/src/components/CalculationList/index.jsx
+++ b/src/components/CalculationList/index.jsx
@@ -467,12 +467,10 @@ const CalculationList = ({
                   <Clock size={14} />
                   <span>{getTimeAgo(calculation.updatedAt.toDate())}</span>
                 </div>
-                {/* TODO: Uncomment this when view tracking is implemented
                 <div className="meta-item">
                   <Eye size={14} />
                   <span>{calculation.views || 0} visualizações</span>
                 </div>
-                */}
               </div>
             </div>
 


### PR DESCRIPTION
### 🔧 O que foi corrigido
Corrigido o contador de visualizações (views) dos cálculos, que já existia, mas não estava atualizando corretamente no Firestore nem refletindo na interface.
Corrigido o caminho da coleção no Firestore de "calculation" para "calculations", que impedia o incremento correto.
Ajustada a função responsável por incrementar as visualizações:
Agora cria o campo views caso ele não exista.
Incrementa corretamente o valor sempre que o modal de um cálculo é aberto.
Implementada atualização do estado local (calculations e filteredCalculations) após o incremento, garantindo que o valor atualizado seja exibido imediatamente na interface, sem necessidade de recarregar a página.
### 🚀 Motivação
Esta correção resolve problemas que impediam a contagem de visualizações de funcionar corretamente. Assim, é possível ter controle real sobre quantas vezes cada cálculo foi acessado, o que melhora a análise de uso da aplicação e a experiência dos administradores.

### ✔️ Checklist
- [x]  Caminho da coleção ajustado para "calculations".
- [x]  Incremento funcionando corretamente no Firestore.
- [x]  Campo views criado automaticamente se não existir.
- [x]  Estado local atualizado após o incremento.
- [x]  Interface reflete o valor atualizado.
- [x]  Testado localmente e funcionando conforme esperado.

Closes #268